### PR TITLE
Allow customising CFBundleIdentifier for macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ All options should added in your app's package.json file. Possible options with 
     "appFriendlyName": "(the 'name' value in your package.json, made titlecase and with '_' and '-' characters replaced with spaces)",
     // A path to a .icns file to use for generating the macOS icon
     "appMacIcon": null,
+    // Unique, case sensitive bundle identifier in reverse-DNS format. Should be changed to prevent ID collisions
+    "appMacBundleIdentifier": "io.nwjs.nwjs",
     // A path to an .ico file to use for generating the Windows icon
     "appWinIcon": null,
     // A short description of the app. Used in the macOS Info.plist and Windows fileVersion.

--- a/bin/builder/BuilderOsx.js
+++ b/bin/builder/BuilderOsx.js
@@ -59,6 +59,7 @@
           "keysToUpdate": {
             "CFBundleDisplayName": this.options.appFriendlyName,
             "CFBundleExecutable": this.options.appFriendlyName,
+            "CFBundleIdentifier": this.options.appMacBundleIdentifier,
             "CFBundleName": this.options.appFriendlyName
           }
         }
@@ -73,6 +74,7 @@
             "keysToUpdate": {
               "CFBundleDisplayName": this.options.appFriendlyName,
               "CFBundleExecutable": this.options.appFriendlyName,
+              "CFBundleIdentifier": `${this.options.appMacBundleIdentifier}.helper`,
               "CFBundleName": this.options.appFriendlyName
             }
           },
@@ -81,6 +83,7 @@
             "keysToUpdate": {
               "CFBundleDisplayName": this.options.appFriendlyName,
               "CFBundleExecutable": this.options.appFriendlyName,
+              "CFBundleIdentifier": `${this.options.appMacBundleIdentifier}.helper.plugin`,
               "CFBundleName": this.options.appFriendlyName
             }
           },
@@ -89,6 +92,7 @@
             "keysToUpdate": {
               "CFBundleDisplayName": this.options.appFriendlyName,
               "CFBundleExecutable": this.options.appFriendlyName,
+              "CFBundleIdentifier": `${this.options.appMacBundleIdentifier}.helper.renderer`,
               "CFBundleName": this.options.appFriendlyName
             }
           },
@@ -97,6 +101,7 @@
             "keysToUpdate": {
               "CFBundleDisplayName": this.options.appFriendlyName,
               "CFBundleExecutable": this.options.appFriendlyName,
+              "CFBundleIdentifier": `${this.options.appMacBundleIdentifier}.helper`,
               "CFBundleName": this.options.appFriendlyName
             }
           }
@@ -112,6 +117,7 @@
             "keysToUpdate": {
               "CFBundleDisplayName": this.options.appFriendlyName,
               "CFBundleExecutable": this.options.appFriendlyName,
+              "CFBundleIdentifier": `${this.options.appMacBundleIdentifier}.helper`,
               "CFBundleName": this.options.appFriendlyName
             }
           }

--- a/bin/index.js
+++ b/bin/index.js
@@ -63,6 +63,9 @@
       "appFriendlyName": Utils.titleCase(packageJSON["name"].replace(/[-_]/g, " ")),
       // A path to a .icns file to use for generating the macOS icon
       "appMacIcon": null,
+      // Unique, case sensitive bundle identifier in reverse-DNS format. Should be changed to prevent ID collisions
+      // See https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier
+      "appMacBundleIdentifier": "io.nwjs.nwjs",
       // A path to an .ico file to use for generating the Windows icon
       "appWinIcon": null,
       // A short description of the app. Used in the macOS Info.plist and Windows fileVersion.


### PR DESCRIPTION
Attempt to fix #19 
Untested because I couldn't get the `npm link` stuff to work for some reason, feel free to use as a base, change wording or option name or throw away and redo it it's the wrong approach/doesn't work.

I used the naming scheme of the existing CFBundleIdentifiers of the Helper .apps, 2 Helpers (GPU and just Helper) already have the same Identifier so I didn't change that part.